### PR TITLE
dlm_lifecycle_policy.markdown - added newer intervals

### DIFF
--- a/website/docs/r/dlm_lifecycle_policy.markdown
+++ b/website/docs/r/dlm_lifecycle_policy.markdown
@@ -124,7 +124,7 @@ The following arguments are supported:
 
 #### Create Rule arguments
 
-* `interval` - (Required) How often this lifecycle policy should be evaluated. `12` or `24` are valid values.
+* `interval` - (Required) How often this lifecycle policy should be evaluated. `2`,`3`,`4`,`6`,`8`,`12` or `24` are valid values.
 * `interval_unit` - (Optional) The unit for how often the lifecycle policy should be evaluated. `HOURS` is currently the only allowed value and also the default value.
 * `times` - (Optional) A list of times in 24 hour clock format that sets when the lifecycle policy should be evaluated. Max of 1.
 


### PR DESCRIPTION
2,3,4,6,8 have been added to the intervals.

This was introduced in 2.1

Addresses changes to code in #7751

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7751

Changes proposed in this pull request:

* Add intervals to the dlm_lifecycle_policy documentation - 2,3,4,6,8